### PR TITLE
Fix autoloader path

### DIFF
--- a/woocommerce-xero-stripe-fees.php
+++ b/woocommerce-xero-stripe-fees.php
@@ -49,7 +49,7 @@ add_action( 'plugins_loaded', 'xerostripefees' );
 /**
  * Updater
  */
-require_once 'vendor/autoload.php';
+require_once __DIR__ . '/vendor/autoload.php';
 $xerostripefees_updater = \Puc_v4_Factory::buildUpdateChecker(
 	'https://github.com/dfinnema/woocommerce-xero-stripe-fees',
 	__FILE__,


### PR DESCRIPTION
The Composer autoloader is being included with a relative path, which breaks when using WP-CLI, as the include path is relative to the working directory.

Using an absolute path fixes this.

```
Fatal error: Uncaught Error: Class 'Puc_v4_Factory' not found in /srv/www/site/current/web/app/plugins/woocommerce-xero-stripe-fees-master/woocommerce-xero-stripe-fees.php:56
Stack trace:
#0 /srv/www/site/current/web/wp/wp-settings.php(377): include_once()
#1 phar:///usr/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(1237): require('/srv/www/dietit...')
#2 phar:///usr/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Runner.php(1158): WP_CLI\Runner->load_wordpress()
#3 phar:///usr/bin/wp/vendor/wp-cli/wp-cli/php/WP_CLI/Bootstrap/LaunchRunner.php(23): WP_CLI\Runner->start()
#4 phar:///usr/bin/wp/vendor/wp-cli/wp-cli/php/bootstrap.php(74): WP_CLI\Bootstrap\LaunchRunner->process(Object(WP_CLI\Bootstrap\BootstrapState))
#5 phar:///usr/bin/wp/vendor/wp-cli/wp-cli/php/wp-cli.php(27): WP_CLI\bootstrap()
#6 phar:///usr/bin/wp/php/boot-phar.php(11): include('phar:///usr/bin...')
#7 /usr/bin/wp(4): include('phar:///usr/bin...')
#8 {main}
  thrown in /srv/www/site/current/web/app/plugins/woocommerce-xero-stripe-fees-master/woocommerce-xero-stripe-fees.php on line 56
```